### PR TITLE
Update SUBMARINER_BROKER_URL to use https endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ helm install submariner-latest/submariner-k8s-broker \
 Once you install the broker, you can retrieve the Kubernetes API server information (if not known) and service account token for the client by utilizing the following commands:
 
 ```
-SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[0].port}")
+SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
 
 SUBMARINER_BROKER_CA=$(kubectl -n ${SUBMARINER_BROKER_NS} get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-client')].data['ca\.crt']}")
 


### PR DESCRIPTION
Normally in a vanilla kubernetes deployment, there is a single endpoint for kubernetes as shown below.
[centos@eosmaster ~]$ kubectl -n default get endpoints kubernetes -o json
<SNIP>
       "ports": [
           {
               "name": "https",
               "port": 6443,
               "protocol": "TCP"
           }
       ]

However, in some deployments (like OpenShift), there could be multiple endpoints.
[centos@wosmaster ~]$ oc -n default get endpoints kubernetes -o json
<SNIP>
       "ports": [
           {
               "name": "dns",
               "port": 8053,
               "protocol": "UDP"
           },
           {
               "name": "https",
               "port": 8443,
               "protocol": "TCP"
           },
           {
               "name": "dns-tcp",
               "port": 8053,
               "protocol": "TCP"
           }
       ]

This patch updates the SUBMARINER_BROKER_URL to use the appropriate "https" endpoint.