### PR TITLE
Update the installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,13 +190,6 @@ Each cluster that will be connected must have Submariner installed within it. Yo
    ```
    kubectl -n kube-system  rollout status deploy/tiller-deploy
    ```
-1. Grant the appropriate security context for the service accounts (if required)
-   
-   For installation based on platforms like Openshift, the service account user needs to be associated with the appropriate security context. This may not be required for Kubernetes based installations as by default security context constraints are not configured in Kubernetes.
-   ```
-   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
-   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
-   ```
 1. Install submariner into this cluster. The values within the following command correspond to the table below.
 
    ```

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ If you don't see a command prompt, try pressing enter.
 
 When running in AWS, it is necessary to disable source/dest checking of the instances that are gateway hosts to allow the instances to pass traffic for remote clusters. 
 
-
 ### Openshift Notes
 
 When running in Openshift, we need to grant the appropriate security context for the service accounts
@@ -248,7 +247,8 @@ When running in Openshift, we need to grant the appropriate security context for
    ```
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
    oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
-
+   ```
+   
 # Building/Contributing
 
 To build `submariner-engine` and `submariner-route-agent` you can trigger `make`, which will perform a Dapperized build of the components.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Each cluster that will be connected must have Submariner installed within it. Yo
    ```
    kubectl -n kube-system  rollout status deploy/tiller-deploy
    ```
-1. Grant  the appropriate security context for the service accounts (if required)
+1. Grant the appropriate security context for the service accounts (if required)
    
    For installation based on platforms like Openshift, the service account user needs to be associated with the appropriate security context. This may not be required for Kubernetes based installations as by default security context constraints are not configured in Kubernetes.
    ```
@@ -246,6 +246,15 @@ If you don't see a command prompt, try pressing enter.
 ### AWS Notes
 
 When running in AWS, it is necessary to disable source/dest checking of the instances that are gateway hosts to allow the instances to pass traffic for remote clusters. 
+
+
+### Openshift Notes
+
+When running in Openshift, we need to grant the appropriate security context for the service accounts
+   
+   ```
+   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
+   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
 
 # Building/Contributing
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,13 @@ Each cluster that will be connected must have Submariner installed within it. Yo
    ```
    kubectl -n kube-system  rollout status deploy/tiller-deploy
    ```
+1. Grant  the appropriate security context for the service accounts (if required)
    
+   For installation based on platforms like Openshift, the service account user needs to be associated with the appropriate security context. This may not be required for Kubernetes based installations as by default security context constraints are not configured in Kubernetes.
+   ```
+   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-routeagent
+   oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-engine 
+   ```
 1. Install submariner into this cluster. The values within the following command correspond to the table below.
 
    ```


### PR DESCRIPTION
The installation steps are updated to include the configurations required for granting the service account the appropriate security context constraints.

While deploying Submariner in Openshift on the Data nodes, it is seen that Submariner and Submariner-routeagent DaemonSet pods move to error state due to security context constraints.

Error:
oc describe ds submariner-routeagent

<SNIP>

---- ------ ---- ---- -------
Warning FailedCreate 2m (x65 over 4h) daemonset-controller Error creating: pods "submariner-routeagent-" is forbidden: unable to validate against any security context constraint: [provider restricted: .spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed capabilities.add: Invalid value: "ALL": capability may not be added spec.containers[0].securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used]

This patch adds the steps required to solve it for the deployments(like Openshift), where this can be an issue.