### PR TITLE
Improve error handling/reporting in kubernetes.go

### DIFF
--- a/pkg/datastore/kubernetes/kubernetes.go
+++ b/pkg/datastore/kubernetes/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/submariner/pkg/types"
 	"github.com/rancher/submariner/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
@@ -115,7 +116,7 @@ func (k *k8s) GetCluster(clusterId string) (types.SubmarinerCluster, error) {
 	k8sClusters, err := k.client.SubmarinerV1().Clusters(k.remoteNamespace).List(metav1.ListOptions{})
 
 	if err != nil {
-		return types.SubmarinerCluster{}, nil
+		return types.SubmarinerCluster{}, err
 	}
 
 	for _, cluster := range k8sClusters.Items {
@@ -152,7 +153,7 @@ func (k *k8s) GetEndpoint(clusterId string, cableName string) (types.SubmarinerE
 	k8sEndpoints, err := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).List(metav1.ListOptions{})
 
 	if err != nil {
-		return types.SubmarinerEndpoint{}, nil
+		return types.SubmarinerEndpoint{}, err
 	}
 
 	for _, endpoint := range k8sEndpoints.Items {
@@ -172,20 +173,21 @@ func (k *k8s) WatchClusters(ctx context.Context, selfClusterId string, colorCode
 			if object, ok = obj.(*submarinerv1.Cluster); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to a Cluster", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Cluster)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to a Cluster", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onClusterChange(types.SubmarinerCluster{
+
+			utilruntime.HandleError(onClusterChange(types.SubmarinerCluster{
 				ID: object.Spec.ClusterID,
 				Spec: object.Spec,
-			}, false)
+			}, false))
 		},
 		UpdateFunc: func (old, obj interface{}) {
 			var object *submarinerv1.Cluster
@@ -194,20 +196,21 @@ func (k *k8s) WatchClusters(ctx context.Context, selfClusterId string, colorCode
 			if object, ok = obj.(*submarinerv1.Cluster); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to a Cluster", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Cluster)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to a Cluster", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onClusterChange(types.SubmarinerCluster{
+
+			utilruntime.HandleError(onClusterChange(types.SubmarinerCluster{
 				ID: object.Spec.ClusterID,
 				Spec: object.Spec,
-			}, false)
+			}, false))
 		},
 		DeleteFunc: func (obj interface{}) {
 			var object *submarinerv1.Cluster
@@ -216,20 +219,21 @@ func (k *k8s) WatchClusters(ctx context.Context, selfClusterId string, colorCode
 			if object, ok = obj.(*submarinerv1.Cluster); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to a Cluster", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Cluster)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to a Cluster", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onClusterChange(types.SubmarinerCluster{
+
+			utilruntime.HandleError(onClusterChange(types.SubmarinerCluster{
 				ID: object.Spec.ClusterID,
 				Spec: object.Spec,
-			}, true)
+			}, true))
 		},
 	}, time.Second * 30)
 
@@ -246,19 +250,20 @@ func (k *k8s) WatchEndpoints(ctx context.Context, selfClusterId string, colorCod
 			if object, ok = obj.(*submarinerv1.Endpoint); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to an Endpoint", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Endpoint)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to an Endpoint", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onEndpointChange(types.SubmarinerEndpoint{
+
+			utilruntime.HandleError(onEndpointChange(types.SubmarinerEndpoint{
 				Spec: object.Spec,
-			}, false)
+			}, false))
 		},
 		UpdateFunc: func (old, obj interface{}) {
 			var object *submarinerv1.Endpoint
@@ -267,19 +272,20 @@ func (k *k8s) WatchEndpoints(ctx context.Context, selfClusterId string, colorCod
 			if object, ok = obj.(*submarinerv1.Endpoint); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to an Endpoint", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Endpoint)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to an Endpoint", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onEndpointChange(types.SubmarinerEndpoint{
+
+			utilruntime.HandleError(onEndpointChange(types.SubmarinerEndpoint{
 				Spec: object.Spec,
-			}, false)
+			}, false))
 		},
 		DeleteFunc: func (obj interface{}) {
 			var object *submarinerv1.Endpoint
@@ -288,19 +294,20 @@ func (k *k8s) WatchEndpoints(ctx context.Context, selfClusterId string, colorCod
 			if object, ok = obj.(*submarinerv1.Endpoint); !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					klog.Errorf("problem decoding object")
+					klog.Errorf("Could not convert object %v to an Endpoint", obj)
 					return
 				}
 				object, ok = tombstone.Obj.(*submarinerv1.Endpoint)
 				if !ok {
-					klog.Errorf("problem decoding object tombstone")
+					klog.Errorf("Could not convert object tombstone %v to an Endpoint", tombstone.Obj)
 					return
 				}
 				klog.V(6).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 			}
-			onEndpointChange(types.SubmarinerEndpoint{
+
+			utilruntime.HandleError(onEndpointChange(types.SubmarinerEndpoint{
 				Spec: object.Spec,
-			}, true)
+			}, true))
 		},
 	}, time.Second * 30)
 
@@ -310,22 +317,24 @@ func (k *k8s) WatchEndpoints(ctx context.Context, selfClusterId string, colorCod
 func (k *k8s) SetCluster(cluster types.SubmarinerCluster) error {
 	clusterCRDName, err := util.GetClusterCRDName(cluster)
 	if err != nil {
-		klog.Errorf("encountered error while parsing submarinercluster to cluster CRD name: %v", err)
-		return err
+		return fmt.Errorf("Error converting the Cluster CRD name: %v", err)
 	}
 
 	retrievedCluster, err := k.client.SubmarinerV1().Clusters(k.remoteNamespace).Get(clusterCRDName, metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("error while retrieving cluster from remote kubernetes broker: %v", err)
-		klog.V(4).Infof("There was an error retrieving the cluster CRD, assuming it does not exist and creating a new one")
+		klog.V(4).Infof("There was an error retrieving the remote Cluster CRD for %s, assuming it does not exist and creating a new one. The error was: %v",
+		    clusterCRDName, err)
 		newClusterObject := &submarinerv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta {
 				Name: clusterCRDName,
 			},
 			Spec: cluster.Spec,
 		}
-		k.client.SubmarinerV1().Clusters(k.remoteNamespace).Create(newClusterObject)
-		return nil
+
+		_, err = k.client.SubmarinerV1().Clusters(k.remoteNamespace).Create(newClusterObject)
+		if err != nil {
+			return fmt.Errorf("Error creating Cluster CRD %s in the remote broker: %v", clusterCRDName, err)
+		}
 	} else {
 		if reflect.DeepEqual(cluster.Spec, retrievedCluster.Spec) {
 			klog.V(4).Infof("Cluster CRD matched what we received from k8s broker, not reconciling")
@@ -334,14 +343,14 @@ func (k *k8s) SetCluster(cluster types.SubmarinerCluster) error {
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			result, getErr := k.client.SubmarinerV1().Clusters(k.remoteNamespace).Get(clusterCRDName, metav1.GetOptions{})
 			if getErr != nil {
-				panic(fmt.Errorf("failed to get latest version of cluster: %v", getErr))
+				return fmt.Errorf("Error retrieving latest version of Cluster %s: %v", clusterCRDName, getErr)
 			}
 			result.Spec = cluster.Spec
 			_, updateErr := k.client.SubmarinerV1().Clusters(k.remoteNamespace).Update(result)
 			return updateErr
 		})
 		if retryErr != nil {
-			panic(fmt.Errorf("update failed: %v", retryErr))
+			return fmt.Errorf("Error updating Cluster CRD %s in remote broker: %v", clusterCRDName, retryErr)
 		}
 	}
 	return nil
@@ -349,22 +358,24 @@ func (k *k8s) SetCluster(cluster types.SubmarinerCluster) error {
 func (k *k8s) SetEndpoint(endpoint types.SubmarinerEndpoint) error {
 	endpointCRDName, err := util.GetEndpointCRDName(endpoint)
 	if err != nil {
-		klog.Errorf("encountered error while parsing submarinerendpoint to endpoint CRD name: %v", err)
-		return err
+		return fmt.Errorf("Error converting the Endpoint CRD name: %v", err)
 	}
 
 	retrievedEndpoint, err := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Get(endpointCRDName, metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("error while retrieving endpoint from remote kubernetes broker: %v", err)
-		klog.V(4).Infof("There was an error retrieving the endpoint CRD, assuming it does not exist and creating a new one")
+		klog.V(4).Infof("There was an error retrieving the local Endpoint CRD for %s, assuming it does not exist and creating a new one. The error was: %v",
+		    endpointCRDName, err)
 		newEndpointObject := &submarinerv1.Endpoint{
 			ObjectMeta: metav1.ObjectMeta {
 				Name: endpointCRDName,
 			},
 			Spec: endpoint.Spec,
 		}
-		k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Create(newEndpointObject)
-		return nil
+
+		_, err = k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Create(newEndpointObject)
+		if err != nil {
+			return fmt.Errorf("Error creating Endpoint CRD %s in the remote broker: %v", endpointCRDName, err)
+		}
 	} else {
 		if reflect.DeepEqual(endpoint.Spec, retrievedEndpoint.Spec) {
 			klog.V(4).Infof("Endpoint CRD matched what we received from k8s broker, not reconciling")
@@ -373,14 +384,14 @@ func (k *k8s) SetEndpoint(endpoint types.SubmarinerEndpoint) error {
 		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			result, getErr := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Get(endpointCRDName, metav1.GetOptions{})
 			if getErr != nil {
-				panic(fmt.Errorf("failed to get latest version of endpoint: %v", getErr))
+				return fmt.Errorf("Error retrieving latest version of Endpoint %s: %v", endpointCRDName, getErr)
 			}
 			result.Spec = endpoint.Spec
 			_, updateErr := k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Update(result)
 			return updateErr
 		})
 		if retryErr != nil {
-			panic(fmt.Errorf("update failed: %v", retryErr))
+			return fmt.Errorf("Error updating endpoint CRD %s: %v", endpointCRDName, retryErr)
 		}
 	}
 	return nil
@@ -389,7 +400,7 @@ func (k *k8s) RemoveEndpoint(clusterId, cableName string) error {
 	endpointName, err := util.GetEndpointCRDNameFromParams(clusterId, cableName)
 
 	if err != nil {
-		return fmt.Errorf("error while removing endpoint, encountered error while converting name: %v", err)
+		return fmt.Errorf("Error converting the Endpoint CRD name: %v", err)
 	}
 
 	return k.client.SubmarinerV1().Endpoints(k.remoteNamespace).Delete(endpointName, &metav1.DeleteOptions{})


### PR DESCRIPTION
  - There were several call sites that did not check the error return value.
    Either propagate the error or at least log it.

  - There were several calls to panic in cases where an update operation failed.
    It seems a bit harsh to terminate in this case and is inconsistent with the
    handling of other failed CRUD operations (which previously ignored errors).
    For consistency, CRUD failures now return and propagate the error.

  - Added format args to some log messages to provide more context

  - Modified the wording in some log messages for consistency