### PR TITLE
Stop printing stack traces on some fatal errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,17 +60,17 @@ func main() {
 
 	cfg, err := clientcmd.BuildConfigFromFlags(localMasterUrl, localKubeconfig)
 	if err != nil {
-		klog.Fatalf("Error building kubeconfig: %s", err.Error())
+		klog.Exitf("Error building kubeconfig: %s", err.Error())
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		klog.Fatalf("Error building kubernetes clientset: %s", err.Error())
+		klog.Exitf("Error building kubernetes clientset: %s", err.Error())
 	}
 
 	submarinerClient, err := submarinerClientset.NewForConfig(cfg)
 	if err != nil {
-		klog.Fatalf("Error building submariner clientset: %s", err.Error())
+		klog.Exitf("Error building submariner clientset: %s", err.Error())
 	}
 
 	kubeInformerFactory := kubeInformers.NewSharedInformerFactoryWithOptions(kubeClient, time.Second*30, kubeInformers.WithNamespace(ss.Namespace))


### PR DESCRIPTION
When exiting from main() because of a configuration error, the stack
traces aren’t useful and would only confuse users. This patch uses
Exitf() instead of Fatalf(), which still exits, but with code 1
instead of 255, and no stack trace.

Signed-off-by: Stephen Kitt <skitt@redhat.com>