### PR TITLE
Add initial support for travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+dist: xenial
+language: go
+
+git:
+  depth: 1
+
+script:
+  - make


### PR DESCRIPTION
Add initial support for travisci. Allow external contributors to perform dapper build, based on existing scripts in travisci.