### PR TITLE
Fix inter cluster POD to POD(non-Gw) connectivity issue

### DIFF
--- a/pkg/cableengine/ipsec/ipsec.go
+++ b/pkg/cableengine/ipsec/ipsec.go
@@ -338,6 +338,18 @@ func (i *Engine) InstallCable(endpoint types.SubmarinerEndpoint) error {
 		}
 	}
 
+	// MASQUERADE (on the GatewayNode) the incoming traffic from the remote cluster (i.e, remoteEndpointIP)
+	// and destined to the local PODs (i.e., localSubnet) scheduled on the non-gateway node.
+	// This will make the return traffic from the POD to go via the GatewayNode.
+	for _, localSubnet := range i.LocalSubnets {
+		ruleSpec := []string{"-s", remoteEndpointIP, "-d", localSubnet, "-j", "MASQUERADE"}
+		klog.V(8).Infof("Installing iptables rule for MASQ incoming traffic: %s", strings.Join(ruleSpec, " "))
+		err = ipt.AppendUnique("nat", "SUBMARINER-POSTROUTING", ruleSpec...)
+		if err != nil {
+			klog.Errorf("error while installing iptables MASQ rule: %v", err)
+		}
+	}
+
 	klog.V(2).Infof("Loaded connection: %v", endpoint.Spec.CableName)
 
 	return nil


### PR DESCRIPTION
OpenShift SDN programs pipeline as follows.
1. For the traffic that is destined to the Cluster network
 (i.e., destination IP is a POD/Service IP and is not on the same node),
 it steers the traffic over the VxLAN tunnels that are configured between
 the Nodes in the Cluster.
2. For non-cluster traffic, OVS pipeline steers the traffic over the tun0
 interface and then over the physical interface and finally to the default
 Gateway configured on the Node.

When we install Submariner with OpenShift 3.11 (ovs-subnet SDN) and
try to ping from POD1 on West Cluster to POD2 (on non-Gateway Node)
of East Cluster, the sourceIP of the traffic seen on POD2 will be the
GatewayNodeIpOfWestCluster.

So, the return traffic from the POD was going over the tun0 interface to the
default-gw configured on the Node and NOT via the SubmarinerGatewayNode on
the localCluster. The fix for the issue is to MASQ the incoming traffic on the
SubmarinerGatewayNode before forwarding it to the Node on which the POD is
scheduled. For Submariner to work the return traffic from POD2 has to go via
the SubmarinerGatewayNode of localCluster.

Note: It is seen that flannel SDN does this by default and hence there was no
need for the MASQ rule.