### PR TITLE
Added unit tests for util.go using ginkgo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ strongswan
 package/strongswan-*
 .project
 .settings
+*.coverprofile

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,7 +20,8 @@ RUN apt-get -q update && \
     curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${LINT_VERSION} && \
     curl https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-amd64.tar.gz | tar -xzf - && \
     cp linux-${ARCH}/helm /usr/bin/ && \
-    curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-${ARCH} && chmod a+x /usr/bin/kind
+    curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-${ARCH} && chmod a+x /usr/bin/kind && \
+    go get -v github.com/onsi/ginkgo/ginkgo && go get -v github.com/onsi/gomega/...
 
 WORKDIR ${DAPPER_SOURCE}
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		}
 
 		localEndpoint, err := util.GetLocalEndpoint(submSpec.ClusterID, "ipsec", nil, submSpec.NatEnabled,
-			append(submSpec.ServiceCidr, submSpec.ClusterCidr...))
+			append(submSpec.ServiceCidr, submSpec.ClusterCidr...), util.GetLocalIP())
 
 		if err != nil {
 			klog.Fatalf("Fatal error occurred while retrieving local endpoint from %#v: %v", submSpec, err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -136,6 +136,10 @@ func GetEndpointCRDNameFromParams(clusterID, cableName string) (string, error) {
 }
 
 func GetClusterCRDName(cluster types.SubmarinerCluster) (string, error) {
+	if cluster.Spec.ClusterID == "" {
+		return "", fmt.Errorf("ClusterID was nil or empty")
+	}
+
 	return cluster.Spec.ClusterID, nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -137,7 +137,7 @@ func GetEndpointCRDNameFromParams(clusterID, cableName string) (string, error) {
 
 func GetClusterCRDName(cluster types.SubmarinerCluster) (string, error) {
 	if cluster.Spec.ClusterID == "" {
-		return "", fmt.Errorf("ClusterID was nil or empty")
+		return "", fmt.Errorf("ClusterID was empty")
 	}
 
 	return cluster.Spec.ClusterID, nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,20 +34,19 @@ func getConnectSecret(token string) (string, error) {
 }
 
 func ParseSecure(token string) (types.Secure, error) {
-	if len(token) != tokenLength {
-		klog.Fatalf("Token %s length was not %d", token, tokenLength)
-	}
-	secure := types.Secure{}
-	var err error
-	secure.SecretKey, err = getConnectSecret(token)
+	secretKey, err := getConnectSecret(token)
 	if err != nil {
-		klog.Fatalf("Could not parse token to secret")
+		return types.Secure{}, err
 	}
-	secure.APIKey, err = getAPIIdentifier(token)
+
 	if err != nil {
-		klog.Fatalf("Could not parse token to apikey")
+		return types.Secure{}, err
 	}
-	return secure, nil
+
+	return types.Secure{
+		APIKey: apiKey,
+		SecretKey: secretKey,
+	}, nil
 }
 
 func GetLocalIP() net.IP {
@@ -63,6 +62,10 @@ func GetLocalIP() net.IP {
 }
 
 func FlattenColors(colorCodes []string) string {
+	if len(colorCodes) == 0 {
+		return ""
+	}
+
 	flattenedColors := colorCodes[0]
 	for k, v := range colorCodes {
 		if k != 0 {

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -6,241 +6,262 @@ import (
 
 	subv1 "github.com/rancher/submariner/pkg/apis/submariner.io/v1"
 	"github.com/rancher/submariner/pkg/types"
-	. "github.com/rancher/submariner/pkg/util"
+	"github.com/rancher/submariner/pkg/util"
 )
 
 var _ = Describe("Util", func() {
-	Describe("Function ParseSecure", func() {
-		Context("With a valid token input", func() {
-			It("should return a valid Secure object", func() {
-				apiKey := "AValidAPIKeyWithLengthThirtyTwo!"
-				secretKey := "AValidSecretKeyWithLength32Chars"
-				secure, err := ParseSecure(apiKey + secretKey)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(secure.ApiKey).To(Equal(apiKey))
-				Expect(secure.SecretKey).To(Equal(secretKey))
-			})
-		})
-
-		Context("With an invalid token input", func() {
-			It("should return an error", func() {
-				_, err := ParseSecure("InvalidToken")
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
+	Describe("Function ParseSecure", testParseSecure)
 	
-	Describe("Function GetLocalIP", func() {
-		It("should return a non-nil IP", func() {
-			Expect(GetLocalIP()).NotTo(BeNil())
-		})
-	})
+	Describe("Function GetLocalIP", testGetLocalIP)
 
-	Describe("Function FlattenColors", func() {
-		Context("With a single element", func() {
-			It("should return the element", func() {
-				Expect(FlattenColors([]string{"blue"})).To(Equal("blue"))
-			})
-		})
+	Describe("Function FlattenColors", testFlattenColors)
 
-		Context("With multiple elements", func() {
-			It("should return a comma-separated string containing all the elements", func() {
-				Expect(FlattenColors([]string{"red", "white", "blue"})).To(Equal("red,white,blue"))
-			})
-		})
-		
-		Context("With no elements", func() {
-			It("should return an empty string", func() {
-				Expect(FlattenColors([]string{})).To(Equal(""))
-			})
-		})
-	})
+	Describe("Function GetLocalCluster", testGetLocalCluster)
 
-	Describe("Function GetLocalCluster", func() {
-		It("should return a valid SubmarinerCluster object", func() {
-			clusterId := "east"
-			clusterCidr := []string{"1.2.3.4/16"}
-			serviceCidr := []string{"5.6.7.8/16"}
-			colorCodes := []string{"red"}
-			cluster, err := GetLocalCluster(types.SubmarinerSpecification {
-				ClusterId: clusterId,
-				ClusterCidr: clusterCidr,
-				ServiceCidr: serviceCidr,
-				ColorCodes: colorCodes,
-			})
+	Describe("Function GetLocalEndpoint", testGetLocalEndpoint)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.ID).To(Equal(clusterId))
-			Expect(cluster.Spec.ClusterID).To(Equal(clusterId))
-			Expect(cluster.Spec.ServiceCIDR).To(Equal(serviceCidr))
-			Expect(cluster.Spec.ClusterCIDR).To(Equal(clusterCidr))
-			Expect(cluster.Spec.ColorCodes).To(Equal(colorCodes))
-		})
-	})
+	Describe("Function GetClusterIdFromCableName", testGetClusterIdFromCableName)
 
-	Describe("Function GetLocalEndpoint", func() {
-		It("should return a valid SubmarinerEndpoint object", func() {
-			subnets := []string{"1.2.3.4/16"}
-			endpoint, err := GetLocalEndpoint("east", "backend", map[string]string{}, false, subnets)
+	Describe("Function GetEndpointCRDName", testGetEndpointCRDName)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(endpoint.Spec.ClusterID).To(Equal("east"))
-			Expect(endpoint.Spec.CableName).To(HavePrefix("submariner-cable-east-"))
-			Expect(endpoint.Spec.Hostname).NotTo(Equal(""))
-			Expect(endpoint.Spec.PrivateIP).NotTo(BeNil())
-			Expect(endpoint.Spec.Backend).To(Equal("backend"))
-			Expect(endpoint.Spec.Subnets).To(Equal(subnets))
-			Expect(endpoint.Spec.NATEnabled).To(Equal(false))
-		})
-	})
+	Describe("Function GetClusterCRDName", testGetClusterCRDName)
 
-	Describe("Function GetClusterIdFromCableName", func() {
-		Context("With a simple embedded cluster ID", func() {
-			It("should extract and return the cluster ID", func() {
-				Expect(GetClusterIdFromCableName("submariner-cable-east-172-16-32-5")).To(Equal("east"))
-			})
-		})
+	Describe("Function CompareEndpointSpec", testCompareEndpointSpec)
 	
-		Context("With an embedded cluster ID containing dashes", func() {
-			It("should extract and return the cluster ID", func() {
-				Expect(GetClusterIdFromCableName("submariner-cable-my-super-long_cluster-id-172-16-32-5")).To(
-					Equal("my-super-long_cluster-id"))
-			})
-		})
-	})
-
-	Describe("Function GetEndpointCRDName", func() {
-		Context("With valid SubmarinerEndpoint input", func() {
-			It("should return <cluster ID>-<cable name>", func() {
-				name, err := GetEndpointCRDName(types.SubmarinerEndpoint {
-					Spec: subv1.EndpointSpec{
-						ClusterID: "ClusterID",
-						CableName: "CableName",
-					},
-				})
-
-				Expect(err).ToNot(HaveOccurred())
-				Expect(name).To(Equal("ClusterID-CableName"))
-			})
-		})
-
-		Context("With a nil cluster ID", func() {
-			It("should return an error", func() {
-				_, err := GetEndpointCRDName(types.SubmarinerEndpoint {
-					Spec: subv1.EndpointSpec{
-						CableName: "CableName",
-					},
-				})
-
-				Expect(err).To(HaveOccurred())
-			})
-		})
-		
-		Context("With a nil cable name", func() {
-			It("should return an error", func() {
-				_, err := GetEndpointCRDName(types.SubmarinerEndpoint {
-					Spec: subv1.EndpointSpec{
-						ClusterID: "ClusterID",
-					},
-				})
-
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-
-	Describe("Function GetClusterCRDName", func() {
-		Context("With valid input", func() {
-			It("should return the cluster ID", func() {
-				Expect(GetClusterCRDName(types.SubmarinerCluster {
-					Spec: subv1.ClusterSpec{
-						ClusterID: "ClusterID",
-					},
-				})).To(Equal("ClusterID"))
-			})
-		})
-
-		Context("With a nil cluster ID", func() {
-			It("should return an error", func() {
-				_, err := GetClusterCRDName(types.SubmarinerCluster {
-					Spec: subv1.ClusterSpec{
-					},
-				})
-
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-
-	Describe("Function CompareEndpointSpec", func() {
-		Context("With equal input", func() {
-			It("should return true", func() {
-				Expect(CompareEndpointSpec(
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "my-host",
-					},
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "my-host",
-					})).To(BeTrue())
-			})
-		})
-
-		Context("With different cluster IDs", func() {
-			It("should return false", func() {
-				Expect(CompareEndpointSpec(
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "my-host",
-					},
-					subv1.EndpointSpec {
-						ClusterID: "west",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "my-host",
-					})).To(BeFalse())
-			})
-		})
-		
-		Context("With different cable names", func() {
-			It("should return false", func() {
-				Expect(CompareEndpointSpec(
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-1-2-3-4",
-						Hostname: "my-host",
-					},
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-5-6-7-8",
-						Hostname: "my-host",
-					})).To(BeFalse())
-			})
-		})
-
-		Context("With different host names", func() {
-			It("should return false", func() {
-				Expect(CompareEndpointSpec(
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "host1",
-					},
-					subv1.EndpointSpec {
-						ClusterID: "east",
-						CableName: "submariner-cable-east-172-16-32-5",
-						Hostname: "host2",
-					})).To(BeFalse())
-			})
-		})
-	})
-
-	Describe("Function GetDefaultGatewayInterface", func() {
-		It("should find and return a non-nil Interface object", func() {
-			Expect(GetDefaultGatewayInterface()).NotTo(BeNil())
-		})
-	})
+	Describe("Function GetDefaultGatewayInterface", testGetDefaultGatewayInterface)
 })
+
+func testParseSecure() {
+	Context("with a valid token input", func() {
+		It("should return a valid Secure object", func() {
+			apiKey := "AValidAPIKeyWithLengthThirtyTwo!"
+			secretKey := "AValidSecretKeyWithLength32Chars"
+			secure, err := util.ParseSecure(apiKey + secretKey)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(secure.ApiKey).To(Equal(apiKey))
+			Expect(secure.SecretKey).To(Equal(secretKey))
+		})
+	})
+
+	Context("with an invalid token input", func() {
+		It("should return an error", func() {
+			_, err := util.ParseSecure("InvalidToken")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testGetLocalIP() {
+	It("should return a non-nil IP", func() {
+		Expect(util.GetLocalIP()).NotTo(BeNil())
+	})
+}
+
+func testFlattenColors() {
+	Context("with a single element", func() {
+		It("should return the element", func() {
+			Expect(util.FlattenColors([]string{"blue"})).To(Equal("blue"))
+		})
+	})
+
+	Context("with multiple elements", func() {
+		It("should return a comma-separated string containing all the elements", func() {
+			Expect(util.FlattenColors([]string{"red", "white", "blue"})).To(Equal("red,white,blue"))
+		})
+	})
+	
+	Context("with no elements", func() {
+		It("should return an empty string", func() {
+			Expect(util.FlattenColors([]string{})).To(Equal(""))
+		})
+	})
+}
+
+func testGetLocalCluster() {
+	It("should return a valid SubmarinerCluster object", func() {
+		clusterId := "east"
+		clusterCidr := []string{"1.2.3.4/16"}
+		serviceCidr := []string{"5.6.7.8/16"}
+		colorCodes := []string{"red"}
+		cluster, err := util.GetLocalCluster(types.SubmarinerSpecification {
+			ClusterId: clusterId,
+			ClusterCidr: clusterCidr,
+			ServiceCidr: serviceCidr,
+			ColorCodes: colorCodes,
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cluster.ID).To(Equal(clusterId))
+		Expect(cluster.Spec.ClusterID).To(Equal(clusterId))
+		Expect(cluster.Spec.ServiceCIDR).To(Equal(serviceCidr))
+		Expect(cluster.Spec.ClusterCIDR).To(Equal(clusterCidr))
+		Expect(cluster.Spec.ColorCodes).To(Equal(colorCodes))
+	})
+}
+
+func testGetLocalEndpoint() {
+	It("should return a valid SubmarinerEndpoint object", func() {
+		subnets := []string{"1.2.3.4/16"}
+		endpoint, err := util.GetLocalEndpoint("east", "backend", map[string]string{}, false, subnets)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(endpoint.Spec.ClusterID).To(Equal("east"))
+		Expect(endpoint.Spec.CableName).To(HavePrefix("submariner-cable-east-"))
+		Expect(endpoint.Spec.Hostname).NotTo(Equal(""))
+		Expect(endpoint.Spec.PrivateIP).NotTo(BeNil())
+		Expect(endpoint.Spec.Backend).To(Equal("backend"))
+		Expect(endpoint.Spec.Subnets).To(Equal(subnets))
+		Expect(endpoint.Spec.NATEnabled).To(Equal(false))
+	})
+}
+
+func testGetClusterIdFromCableName() {
+	Context("with a simple embedded cluster ID", func() {
+		It("should extract and return the cluster ID", func() {
+			Expect(util.GetClusterIdFromCableName("submariner-cable-east-172-16-32-5")).To(Equal("east"))
+		})
+	})
+
+	Context("with an embedded cluster ID containing dashes", func() {
+		It("should extract and return the cluster ID", func() {
+			Expect(util.GetClusterIdFromCableName("submariner-cable-my-super-long_cluster-id-172-16-32-5")).To(
+				Equal("my-super-long_cluster-id"))
+		})
+	})
+}
+
+func testGetEndpointCRDName() {
+	Context("with valid SubmarinerEndpoint input", func() {
+		It("should return <cluster ID>-<cable name>", func() {
+			name, err := util.GetEndpointCRDName(types.SubmarinerEndpoint {
+				Spec: subv1.EndpointSpec{
+					ClusterID: "ClusterID",
+					CableName: "CableName",
+				},
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(name).To(Equal("ClusterID-CableName"))
+		})
+	})
+
+	Context("with a nil cluster ID", func() {
+		It("should return an error", func() {
+			_, err := util.GetEndpointCRDName(types.SubmarinerEndpoint {
+				Spec: subv1.EndpointSpec{
+					CableName: "CableName",
+				},
+			})
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	
+	Context("with a nil cable name", func() {
+		It("should return an error", func() {
+			_, err := util.GetEndpointCRDName(types.SubmarinerEndpoint {
+				Spec: subv1.EndpointSpec{
+					ClusterID: "ClusterID",
+				},
+			})
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testGetClusterCRDName() {
+	Context("with valid input", func() {
+		It("should return the cluster ID", func() {
+			Expect(util.GetClusterCRDName(types.SubmarinerCluster {
+				Spec: subv1.ClusterSpec{
+					ClusterID: "ClusterID",
+				},
+			})).To(Equal("ClusterID"))
+		})
+	})
+
+	Context("with a nil cluster ID", func() {
+		It("should return an error", func() {
+			_, err := util.GetClusterCRDName(types.SubmarinerCluster {
+				Spec: subv1.ClusterSpec{
+				},
+			})
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}
+
+func testCompareEndpointSpec() {
+	Context("with equal input", func() {
+		It("should return true", func() {
+			Expect(util.CompareEndpointSpec(
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "my-host",
+				},
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "my-host",
+				})).To(BeTrue())
+		})
+	})
+
+	Context("with different cluster IDs", func() {
+		It("should return false", func() {
+			Expect(util.CompareEndpointSpec(
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "my-host",
+				},
+				subv1.EndpointSpec {
+					ClusterID: "west",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "my-host",
+				})).To(BeFalse())
+		})
+	})
+	
+	Context("with different cable names", func() {
+		It("should return false", func() {
+			Expect(util.CompareEndpointSpec(
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-1-2-3-4",
+					Hostname: "my-host",
+				},
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-5-6-7-8",
+					Hostname: "my-host",
+				})).To(BeFalse())
+		})
+	})
+
+	Context("with different host names", func() {
+		It("should return false", func() {
+			Expect(util.CompareEndpointSpec(
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "host1",
+				},
+				subv1.EndpointSpec {
+					ClusterID: "east",
+					CableName: "submariner-cable-east-172-16-32-5",
+					Hostname: "host2",
+				})).To(BeFalse())
+		})
+	})
+}
+
+func testGetDefaultGatewayInterface() {
+	It("should find and return a non-nil Interface object", func() {
+		Expect(util.GetDefaultGatewayInterface()).NotTo(BeNil())
+	})
+}
+

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,233 @@
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	subv1 "github.com/rancher/submariner/pkg/apis/submariner.io/v1"
+	"github.com/rancher/submariner/pkg/types"
+	. "github.com/rancher/submariner/pkg/util"
+)
+
+var _ = Describe("Util", func() {
+	Describe("Function ParseSecure", func() {
+		Context("With a valid token input", func() {
+			It("should return a valid Secure object", func() {
+				apiKey := "AValidAPIKeyWithLengthThirtyTwo!"
+				secretKey := "AValidSecretKeyWithLength32Chars"
+				secure, err := ParseSecure(apiKey + secretKey)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(secure.ApiKey).To(Equal(apiKey))
+				Expect(secure.SecretKey).To(Equal(secretKey))
+			})
+		})
+
+		Context("With an invalid token input", func() {
+			It("should return an error", func() {
+				_, err := ParseSecure("InvalidToken")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	
+	Describe("Function GetLocalIP", func() {
+		It("should return a non-nil IP", func() {
+			Expect(GetLocalIP()).NotTo(BeNil())
+		})
+	})
+
+	Describe("Function FlattenColors", func() {
+		Context("With a single element", func() {
+			It("should return the element", func() {
+				Expect(FlattenColors([]string{"blue"})).To(Equal("blue"))
+			})
+		})
+
+		Context("With multiple elements", func() {
+			It("should return a comma-separated string containing all the elements", func() {
+				Expect(FlattenColors([]string{"red", "white", "blue"})).To(Equal("red,white,blue"))
+			})
+		})
+		
+		Context("With no elements", func() {
+			It("should return an empty string", func() {
+				Expect(FlattenColors([]string{})).To(Equal(""))
+			})
+		})
+	})
+
+	Describe("Function GetLocalCluster", func() {
+		It("should return a valid SubmarinerCluster object", func() {
+			clusterId := "east"
+			clusterCidr := []string{"1.2.3.4/16"}
+			serviceCidr := []string{"5.6.7.8/16"}
+			colorCodes := []string{"red"}
+			cluster, err := GetLocalCluster(types.SubmarinerSpecification {
+				ClusterId: clusterId,
+				ClusterCidr: clusterCidr,
+				ServiceCidr: serviceCidr,
+				ColorCodes: colorCodes,
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cluster.ID).To(Equal(clusterId))
+			Expect(cluster.Spec.ClusterID).To(Equal(clusterId))
+			Expect(cluster.Spec.ServiceCIDR).To(Equal(serviceCidr))
+			Expect(cluster.Spec.ClusterCIDR).To(Equal(clusterCidr))
+			Expect(cluster.Spec.ColorCodes).To(Equal(colorCodes))
+		})
+	})
+
+	Describe("Function GetLocalEndpoint", func() {
+		It("should return a valid SubmarinerEndpoint object", func() {
+			subnets := []string{"1.2.3.4/16"}
+			endpoint, err := GetLocalEndpoint("east", "backend", map[string]string{}, false, subnets)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(endpoint.Spec.ClusterID).To(Equal("east"))
+			Expect(endpoint.Spec.CableName).To(HavePrefix("submariner-cable-east-"))
+			Expect(endpoint.Spec.Hostname).NotTo(Equal(""))
+			Expect(endpoint.Spec.PrivateIP).NotTo(BeNil())
+			Expect(endpoint.Spec.Backend).To(Equal("backend"))
+			Expect(endpoint.Spec.Subnets).To(Equal(subnets))
+			Expect(endpoint.Spec.NATEnabled).To(Equal(false))
+		})
+	})
+
+	Describe("Function GetClusterIdFromCableName", func() {
+		Context("With a simple embedded cluster ID", func() {
+			It("should extract and return the cluster ID", func() {
+				Expect(GetClusterIdFromCableName("submariner-cable-east-172-16-32-5")).To(Equal("east"))
+			})
+		})
+	
+		Context("With an embedded cluster ID containing dashes", func() {
+			It("should extract and return the cluster ID", func() {
+				Expect(GetClusterIdFromCableName("submariner-cable-my-super-long_cluster-id-172-16-32-5")).To(
+					Equal("my-super-long_cluster-id"))
+			})
+		})
+	})
+
+	Describe("Function GetEndpointCRDName", func() {
+		Context("With valid SubmarinerEndpoint input", func() {
+			It("should return <cluster ID>-<cable name>", func() {
+				name, err := GetEndpointCRDName(types.SubmarinerEndpoint {
+					Spec: subv1.EndpointSpec{
+						ClusterID: "ClusterID",
+						CableName: "CableName",
+					},
+				})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(name).To(Equal("ClusterID-CableName"))
+			})
+		})
+
+		Context("With a nil cluster ID", func() {
+			It("should return an error", func() {
+				_, err := GetEndpointCRDName(types.SubmarinerEndpoint {
+					Spec: subv1.EndpointSpec{
+						CableName: "CableName",
+					},
+				})
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		
+		Context("With a nil cable name", func() {
+			It("should return an error", func() {
+				_, err := GetEndpointCRDName(types.SubmarinerEndpoint {
+					Spec: subv1.EndpointSpec{
+						ClusterID: "ClusterID",
+					},
+				})
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Function GetClusterCRDName", func() {
+		It("should return the cluster ID", func() {
+			Expect(GetClusterCRDName(types.SubmarinerCluster {
+				Spec: subv1.ClusterSpec{
+					ClusterID: "ClusterID",
+				},
+			})).To(Equal("ClusterID"))
+		})
+	})
+
+	Describe("Function CompareEndpointSpec", func() {
+		Context("With equal input", func() {
+			It("should return true", func() {
+				Expect(CompareEndpointSpec(
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "my-host",
+					},
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "my-host",
+					})).To(BeTrue())
+			})
+		})
+
+		Context("With different cluster IDs", func() {
+			It("should return false", func() {
+				Expect(CompareEndpointSpec(
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "my-host",
+					},
+					subv1.EndpointSpec {
+						ClusterID: "west",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "my-host",
+					})).To(BeFalse())
+			})
+		})
+		
+		Context("With different cable names", func() {
+			It("should return false", func() {
+				Expect(CompareEndpointSpec(
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-1-2-3-4",
+						Hostname: "my-host",
+					},
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-5-6-7-8",
+						Hostname: "my-host",
+					})).To(BeFalse())
+			})
+		})
+
+		Context("With different host names", func() {
+			It("should return false", func() {
+				Expect(CompareEndpointSpec(
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "host1",
+					},
+					subv1.EndpointSpec {
+						ClusterID: "east",
+						CableName: "submariner-cable-east-172-16-32-5",
+						Hostname: "host2",
+					})).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("Function GetDefaultGatewayInterface", func() {
+		It("should find and return a non-nil Interface object", func() {
+			Expect(GetDefaultGatewayInterface()).NotTo(BeNil())
+		})
+	})
+})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -150,12 +150,25 @@ var _ = Describe("Util", func() {
 	})
 
 	Describe("Function GetClusterCRDName", func() {
-		It("should return the cluster ID", func() {
-			Expect(GetClusterCRDName(types.SubmarinerCluster {
-				Spec: subv1.ClusterSpec{
-					ClusterID: "ClusterID",
-				},
-			})).To(Equal("ClusterID"))
+		Context("With valid input", func() {
+			It("should return the cluster ID", func() {
+				Expect(GetClusterCRDName(types.SubmarinerCluster {
+					Spec: subv1.ClusterSpec{
+						ClusterID: "ClusterID",
+					},
+				})).To(Equal("ClusterID"))
+			})
+		})
+
+		Context("With a nil cluster ID", func() {
+			It("should return an error", func() {
+				_, err := GetClusterCRDName(types.SubmarinerCluster {
+					Spec: subv1.ClusterSpec{
+					},
+				})
+
+				Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 

--- a/scripts/test
+++ b/scripts/test
@@ -3,9 +3,10 @@ set -e
 
 cd $(dirname $0)/..
 
-echo Running tests
+echo Looking for packages to test
 
 PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|test)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
+echo Running tests in ${PACKAGES}
 [ "${ARCH}" == "amd64" ] && RACE=-race
-go test ${RACE} -cover -tags=test ${PACKAGES}
+ginkgo ${RACE} -cover -v ${PACKAGES}


### PR DESCRIPTION
Coverage is about 83% - most uncovered lines are on hard-to-hit error paths.

The ParseSecure function was refactored a bit to return errors, as is
declared in the signature, instead of calling Fatalf to exit - it should let
the caller handle the returned error and decide if it's fatal (which the lone
caller does). This also made it easier to write tests for the error conditions.

FlattenColors was modified to handle a null or empty input array so the test
case passes.

The second commit is a follow-up to address a comment wrt GetClusterCRDName.