### PR TITLE
Update Dockerfiles

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,12 +1,15 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 WORKDIR /var/submariner
 
 COPY strongswan*.tar.gz /var/tmp
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && apt-get -y update && apt-get -y install curl iproute2 iptables libatm1 libgmp10 libmnl0 libnfnetlink0 libssl1.0.0
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN /bin/bash -c "cd / && cp /var/tmp/strongswan*.tar.gz . && tar -zxvf strongswan*.tar.gz && rm strongswan*.tar.gz"
+RUN apt-get -y update && \
+    apt-get -y install curl iproute2 iptables libatm1 libgmp10
+
+RUN /bin/bash -c "cd / && tar xf /var/tmp/strongswan*.tar.gz && rm -f /var/tmp/strongswan*.tar.gz"
 
 COPY charon.conf /usr/local/etc/strongswan.d/charon.conf
 COPY submariner.sh /usr/local/bin

--- a/package/Dockerfile.routeagent
+++ b/package/Dockerfile.routeagent
@@ -1,8 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 WORKDIR /var/submariner
 
-RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && apt-get -y update && apt-get -y install iproute2 iptables libatm1 libgmp10 libmnl0 libnfnetlink0 libssl1.0.0
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install iproute2 iptables libatm1 libgmp10
 
 COPY submariner-route-agent.sh /usr/local/bin
 


### PR DESCRIPTION
This upgrades and cleans up the Dockerfiles used for the engine and
router agent:

* upgrade from Ubuntu 16.04 to 18.04
* set DEBIAN_FRONTEND instead of the debconf selection
* reduce the set of explicitly installed packages
* avoid the extra copy on StrongSwan

Signed-off-by: Stephen Kitt <skitt@redhat.com>