### PR TITLE
golint clean-ups

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 			klog.Fatalf("Fatal error occurred creating ipsec engine: %v", err)
 		}
 
-		tunnelController := tunnel.NewTunnelController(submSpec.Namespace, cableEngine, kubeClient, submarinerClient,
+		tunnelController := tunnel.NewController(submSpec.Namespace, cableEngine, kubeClient, submarinerClient,
 			submarinerInformerFactory.Submariner().V1().Endpoints())
 
 		var datastore datastore.Datastore

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/klog"
 )
 
-type TunnelController struct {
+type Controller struct {
 	ce                  cableengine.CableEngine
 	kubeClientSet       kubernetes.Interface
 	submarinerClientSet submarinerClientset.Interface
@@ -29,8 +29,8 @@ type TunnelController struct {
 	endpointWorkqueue workqueue.RateLimitingInterface
 }
 
-func NewTunnelController(objectNamespace string, ce cableengine.CableEngine, kubeClientSet kubernetes.Interface, submarinerClientSet submarinerClientset.Interface, endpointInformer submarinerInformers.EndpointInformer) *TunnelController {
-	tunnelController := &TunnelController{
+func NewController(objectNamespace string, ce cableengine.CableEngine, kubeClientSet kubernetes.Interface, submarinerClientSet submarinerClientset.Interface, endpointInformer submarinerInformers.EndpointInformer) *Controller {
+	tunnelController := &Controller{
 		ce:                  ce,
 		kubeClientSet:       kubeClientSet,
 		submarinerClientSet: submarinerClientSet,
@@ -50,7 +50,7 @@ func NewTunnelController(objectNamespace string, ce cableengine.CableEngine, kub
 	return tunnelController
 }
 
-func (t *TunnelController) Run(stopCh <-chan struct{}) error {
+func (t *Controller) Run(stopCh <-chan struct{}) error {
 	defer utilruntime.HandleCrash()
 
 	// Start the informer factories to begin populating the informer caches
@@ -72,13 +72,13 @@ func (t *TunnelController) Run(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (t *TunnelController) runWorker() {
+func (t *Controller) runWorker() {
 	for t.processNextEndpoint() {
 
 	}
 }
 
-func (t *TunnelController) processNextEndpoint() bool {
+func (t *Controller) processNextEndpoint() bool {
 	obj, shutdown := t.endpointWorkqueue.Get()
 	if shutdown {
 		return false
@@ -115,7 +115,7 @@ func (t *TunnelController) processNextEndpoint() bool {
 	return true
 }
 
-func (t *TunnelController) enqueueEndpoint(obj interface{}) {
+func (t *Controller) enqueueEndpoint(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
@@ -126,7 +126,7 @@ func (t *TunnelController) enqueueEndpoint(obj interface{}) {
 	t.endpointWorkqueue.AddRateLimited(key)
 }
 
-func (t *TunnelController) handleRemovedEndpoint(obj interface{}) {
+func (t *Controller) handleRemovedEndpoint(obj interface{}) {
 	var object *v1.Endpoint
 	var ok bool
 	klog.V(4).Infof("Handling object in handleEndpoint")


### PR DESCRIPTION
* Id → ID (e.g. ClusterId → ClusterID)
* Api → API (e.g. ApiKey → APIKey)
* Drop unused import and unnecessary type specification in main.go
* tunnel.TunnelController → tunner.Controller to avoid stuttering

Signed-off-by: Stephen Kitt <skitt@redhat.com>