### PR TITLE
Refactor route controller to avoid stuttering

### DIFF
--- a/pkg/routeagent/main.go
+++ b/pkg/routeagent/main.go
@@ -53,7 +53,7 @@ func main() {
 	submarinerInformerFactory := submarinerInformers.NewSharedInformerFactoryWithOptions(submarinerClient, time.Second*30, submarinerInformers.WithNamespace(srcs.Namespace))
 
 	defLink, err := util.GetDefaultGatewayInterface()
-	routeController := routecontroller.NewRouteController(srcs.ClusterID, srcs.Namespace, defLink, submarinerClient, submarinerInformerFactory.Submariner().V1().Clusters(), submarinerInformerFactory.Submariner().V1().Endpoints())
+	routeController := route.NewController(srcs.ClusterID, srcs.Namespace, defLink, submarinerClient, submarinerInformerFactory.Submariner().V1().Clusters(), submarinerInformerFactory.Submariner().V1().Endpoints())
 
 	submarinerInformerFactory.Start(stopCh)
 


### PR DESCRIPTION
- Renamed package from routecontroller to route as controller is already in
  the import path and makes it consistent with tunnel.go
- route.RouteController -> route.Controller
- route.NewRouteController -> route.NewController

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>