### PR TITLE
Enable golangci-lint support

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -3,18 +3,4 @@ set -e
 
 cd $(dirname $0)/..
 
-echo Running validation
-
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
-
-echo Running: go vet
-go vet ${PACKAGES}
-echo Running: golint
-for i in ${PACKAGES}; do
-    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | tee /dev/stderr)" ]; then
-        failed=true
-    fi
-done
-test -z "$failed"
-echo Running: go fmt
-test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"
+golangci-lint run -D megacheck -E unused,gosimple,staticcheck


### PR DESCRIPTION
Currently golint and gofmt are used in shadow mode.
I would like to propose to use golangci-lint.
golangci-lint is a linters aggregator. Has number of advantages:
1. It's 5 times faster than gometalinter. 
2. It's easy to integrate and use, has nice output and has a minimum number of false positives. 
3. It supports go modules.
4. Long list of supported linters. https://github.com/golangci/golangci-lint#supported-linters
5. Good IDE integration support. https://github.com/golangci/golangci-lint#editor-integration

This PR will change the **make validate** command to run golangci-lint on demand. 

Test locally with **make validate** command.