### PR TITLE
Provide control over e2e cleanup

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -130,7 +130,14 @@ function cleanup {
   for i in 1 2 3; do kind delete cluster --name=cluster${i}; done
 }
 
-trap cleanup EXIT
+if [[ $1 = -c ]]; then
+    cleanup
+    exit 0
+fi
+
+if [[ $1 != -k ]]; then
+    trap cleanup EXIT
+fi
 
 helm init --client-only
 helm repo add submariner-latest https://releases.rancher.com/submariner-charts/latest


### PR DESCRIPTION
This adds a -k option to keep the clusters running after an e2e run,
and the complementary -c option to destroy the clusters.

Signed-off-by: Stephen Kitt <skitt@redhat.com>