### PR TITLE
Fix make test after E2E being merged

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 echo Running tests
 
-PACKAGES=". $(find -path ./test/e2e -prune -o -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|test)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 [ "${ARCH}" == "amd64" ] && RACE=-race
 go test ${RACE} -cover -tags=test ${PACKAGES}


### PR DESCRIPTION
test/e2e directory is being found by the test script, and
it will fail when go test tries to run it. This stops
test/e2e being found out by the discovery script.