### PR TITLE
Cleanup error handling in ipsec

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/rancher/submariner/pkg/cableengine"
 	"github.com/rancher/submariner/pkg/cableengine/ipsec"
 	"github.com/rancher/submariner/pkg/controllers/datastoresyncer"
 	"github.com/rancher/submariner/pkg/datastore"
@@ -92,7 +91,10 @@ func main() {
 			klog.Fatalf("Fatal error occurred while retrieving local endpoint from %#v: %v", submSpec, err)
 		}
 
-		var cableEngine cableengine.CableEngine = ipsec.NewEngine(append(submSpec.ClusterCidr, submSpec.ServiceCidr...), localCluster, localEndpoint)
+		cableEngine, err := ipsec.NewEngine(append(submSpec.ClusterCidr, submSpec.ServiceCidr...), localCluster, localEndpoint)
+		if err != nil {
+			klog.Fatalf("Fatal error occurred creating ipsec engine: %v", err)
+		}
 
 		tunnelController := tunnel.NewTunnelController(submSpec.Namespace, cableEngine, kubeClient, submarinerClient,
 			submarinerInformerFactory.Submariner().V1().Endpoints())


### PR DESCRIPTION
- Handle all returned errors as flagged by golangci-lint
- Propagate errors instead of calling Fatalf
- Refactored runCharon to propagate the error if cmd.Start() fails.
  Note that prior, cmd.Wait() would've returned an error if cmd.Start()
  failed and and thus immediately exited via Fatalf but I think it's cleaner
  to propagate the error via StartEngine.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>