### PR TITLE
Add test as a phony target to restore "make test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ trash-keep: .dapper
 	./.dapper -m bind trash -k
 
 .DEFAULT_GOAL := ci
+
+.PHONY: test
+


### PR DESCRIPTION
The presence of the test directory broke this.

Signed-off-by: Stephen Kitt <skitt@redhat.com>