### PR TITLE
Cleanup error handling in phpapi

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,7 +107,10 @@ func main() {
 				klog.Fatalf("Error parsing secure token: %v", err)
 			}
 
-			datastore = phpapi.NewPHPAPI(secure.APIKey)
+			datastore, err = phpapi.NewPHPAPI(secure.APIKey)
+			if err != nil {
+				klog.Fatalf("Error creating PHPAPI datastore: %v", err)
+			}
 		case "k8s":
 			datastore, err = subk8s.NewDatastore(submSpec.ClusterID, stopCh)
 			if err != nil {


### PR DESCRIPTION
- Handle all returned errors as flagged by golangci-lint
- Propagate or log errors instead of calling Fatalf
- Improved logging messages where appropriate
- Return error for unimplemented method

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>