### PR TITLE
Change Datastore methods to use pointers

### DIFF
--- a/pkg/controllers/datastoresyncer/datastoresyncer.go
+++ b/pkg/controllers/datastoresyncer/datastoresyncer.go
@@ -83,7 +83,7 @@ func (d *DatastoreSyncer) ensureExclusiveEndpoint() {
 
 	for _, endpoint := range endpoints {
 		if !util.CompareEndpointSpec(endpoint.Spec, d.localEndpoint.Spec) {
-			endpointCrdName, err := util.GetEndpointCRDName(endpoint)
+			endpointCrdName, err := util.GetEndpointCRDName(&endpoint)
 			if err != nil {
 				klog.Errorf("Error while converting endpoint to CRD Name %s", endpoint.Spec.CableName)
 				break
@@ -138,12 +138,12 @@ func (d *DatastoreSyncer) Run(stopCh <-chan struct{}) error {
 
 	d.ensureExclusiveEndpoint()
 
-	err := d.reconcileClusterCRD(d.localCluster, false)
+	err := d.reconcileClusterCRD(&d.localCluster, false)
 	if err != nil {
 		return fmt.Errorf("Error reconciling local Cluster CRD: %v", err)
 	}
 
-	err = d.reconcileEndpointCRD(d.localEndpoint, false)
+	err = d.reconcileEndpointCRD(&d.localEndpoint, false)
 	if err != nil {
 		return fmt.Errorf("Error reconciling local Endpoint CRD: %v", err)
 	}
@@ -199,7 +199,7 @@ func (d *DatastoreSyncer) processNextClusterWorkItem() bool {
 			Spec: cluster.Spec,
 		}
 		klog.V(4).Infof("Attempting to trigger an update of the central datastore with the updated CRD")
-		err = d.datastore.SetCluster(myCluster)
+		err = d.datastore.SetCluster(&myCluster)
 		klog.V(4).Infof("Update of cluster in central datastore was successful")
 		if err != nil {
 			klog.Errorf("There was an error updating the cluster in the central datastore, error: %v", err)
@@ -254,7 +254,7 @@ func (d *DatastoreSyncer) processNextEndpointWorkItem() bool {
 			Spec: endpoint.Spec,
 		}
 		klog.V(4).Infof("Attempting to trigger an update of the central datastore with the updated endpoint CRD")
-		err = d.datastore.SetEndpoint(myEndpoint)
+		err = d.datastore.SetEndpoint(&myEndpoint)
 		if err != nil {
 			klog.Errorf("There was an error updating the endpoint in the central datastore, error: %v", err)
 		} else {
@@ -271,7 +271,7 @@ func (d *DatastoreSyncer) processNextEndpointWorkItem() bool {
 	return true
 }
 
-func (d *DatastoreSyncer) reconcileClusterCRD(localCluster types.SubmarinerCluster, delete bool) error {
+func (d *DatastoreSyncer) reconcileClusterCRD(localCluster *types.SubmarinerCluster, delete bool) error {
 	clusterCRDName, err := util.GetClusterCRDName(localCluster)
 	if err != nil {
 		return fmt.Errorf("Error converting the Cluster CRD name: %v", err)
@@ -400,7 +400,7 @@ func searchEndpoints(endpoints []types.SubmarinerEndpoint, cableName string, clu
 	return false
 }
 
-func (d *DatastoreSyncer) reconcileEndpointCRD(rawEndpoint types.SubmarinerEndpoint, delete bool) error {
+func (d *DatastoreSyncer) reconcileEndpointCRD(rawEndpoint *types.SubmarinerEndpoint, delete bool) error {
 	endpointName, err := util.GetEndpointCRDName(rawEndpoint)
 	if err != nil {
 		return fmt.Errorf("Error converting the Enndpoint CRD name: %v", err)

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -14,22 +14,33 @@ import (
 type Datastore interface {
 	// This gets all clusters that match the color code
 	GetClusters(colorCodes []string) ([]types.SubmarinerCluster, error)
+
 	// This gets a single cluster based on cluster ID and returns a v1.Cluster or error based on what it retrieves
-	GetCluster(clusterID string) (types.SubmarinerCluster, error)
+	GetCluster(clusterID string) (*types.SubmarinerCluster, error)
+
 	// This gets all endpoints for the given cluster ID
 	GetEndpoints(clusterID string) ([]types.SubmarinerEndpoint, error)
+
 	// This gets a single endpoint based on the cluster ID and cableName passed in
-	GetEndpoint(clusterID string, cableName string) (types.SubmarinerEndpoint, error)
+	GetEndpoint(clusterID string, cableName string) (*types.SubmarinerEndpoint, error)
+
 	// Watches all clusters and calls the passed in function on cluster change
-	WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string, onClusterChange func(cluster types.SubmarinerCluster, deleted bool) error) error
+	WatchClusters(ctx context.Context, selfClusterID string, colorCodes []string,
+		onClusterChange func(cluster *types.SubmarinerCluster, deleted bool) error) error
+
 	// Performs a watch of all endpoints and calls the passed in function based on information
-	WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string, onEndpointChange func(endpoint types.SubmarinerEndpoint, deleted bool) error) error
+	WatchEndpoints(ctx context.Context, selfClusterID string, colorCodes []string,
+		onEndpointChange func(endpoint *types.SubmarinerEndpoint, deleted bool) error) error
+
 	// This should be called to set the local cluster information.
-	SetCluster(cluster types.SubmarinerCluster) error
+	SetCluster(cluster *types.SubmarinerCluster) error
+
 	// This should only ever be called to set the endpoint of the local node.
-	SetEndpoint(local types.SubmarinerEndpoint) error
+	SetEndpoint(endpoint *types.SubmarinerEndpoint) error
+
 	// This should be called to remove an endpoint from use
 	RemoveEndpoint(clusterID, cableName string) error
+
 	// This should be called to remove a cluster from use
 	RemoveCluster(clusterID string) error
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -125,7 +125,7 @@ func GetClusterIDFromCableName(cableName string) string {
 	return clusterID
 }
 
-func GetEndpointCRDName(endpoint types.SubmarinerEndpoint) (string, error) {
+func GetEndpointCRDName(endpoint *types.SubmarinerEndpoint) (string, error) {
 	return GetEndpointCRDNameFromParams(endpoint.Spec.ClusterID, endpoint.Spec.CableName)
 }
 
@@ -137,7 +137,7 @@ func GetEndpointCRDNameFromParams(clusterID, cableName string) (string, error) {
 	return fmt.Sprintf("%s-%s", clusterID, cableName), nil
 }
 
-func GetClusterCRDName(cluster types.SubmarinerCluster) (string, error) {
+func GetClusterCRDName(cluster *types.SubmarinerCluster) (string, error) {
 	if cluster.Spec.ClusterID == "" {
 		return "", fmt.Errorf("ClusterID was empty")
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -128,7 +128,7 @@ func testGetClusterIDFromCableName() {
 func testGetEndpointCRDName() {
 	Context("with valid SubmarinerEndpoint input", func() {
 		It("should return <cluster ID>-<cable name>", func() {
-			name, err := util.GetEndpointCRDName(types.SubmarinerEndpoint{
+			name, err := util.GetEndpointCRDName(&types.SubmarinerEndpoint{
 				Spec: subv1.EndpointSpec{
 					ClusterID: "ClusterID",
 					CableName: "CableName",
@@ -142,7 +142,7 @@ func testGetEndpointCRDName() {
 
 	Context("with a nil cluster ID", func() {
 		It("should return an error", func() {
-			_, err := util.GetEndpointCRDName(types.SubmarinerEndpoint{
+			_, err := util.GetEndpointCRDName(&types.SubmarinerEndpoint{
 				Spec: subv1.EndpointSpec{
 					CableName: "CableName",
 				},
@@ -154,7 +154,7 @@ func testGetEndpointCRDName() {
 
 	Context("with a nil cable name", func() {
 		It("should return an error", func() {
-			_, err := util.GetEndpointCRDName(types.SubmarinerEndpoint{
+			_, err := util.GetEndpointCRDName(&types.SubmarinerEndpoint{
 				Spec: subv1.EndpointSpec{
 					ClusterID: "ClusterID",
 				},
@@ -168,7 +168,7 @@ func testGetEndpointCRDName() {
 func testGetClusterCRDName() {
 	Context("with valid input", func() {
 		It("should return the cluster ID", func() {
-			Expect(util.GetClusterCRDName(types.SubmarinerCluster{
+			Expect(util.GetClusterCRDName(&types.SubmarinerCluster{
 				Spec: subv1.ClusterSpec{
 					ClusterID: "ClusterID",
 				},
@@ -178,7 +178,7 @@ func testGetClusterCRDName() {
 
 	Context("with a nil cluster ID", func() {
 		It("should return an error", func() {
-			_, err := util.GetClusterCRDName(types.SubmarinerCluster{
+			_, err := util.GetClusterCRDName(&types.SubmarinerCluster{
 				Spec: subv1.ClusterSpec{},
 			})
 


### PR DESCRIPTION
Several Datastore methods pass or return by value rather than pointers.
Change to pointers for efficiency. This also cascaded to a couple util
methods.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>