### PR TITLE
Update k8s generated code

### DIFF
--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	SubmarinerV1() submarinerv1.SubmarinerV1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Submariner() submarinerv1.SubmarinerV1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // SubmarinerV1 retrieves the SubmarinerV1Client
 func (c *Clientset) SubmarinerV1() submarinerv1.SubmarinerV1Interface {
-	return c.submarinerV1
-}
-
-// Deprecated: Submariner retrieves the default version of SubmarinerClient.
-// Please explicitly pick a version.
-func (c *Clientset) Submariner() submarinerv1.SubmarinerV1Interface {
 	return c.submarinerV1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) SubmarinerV1() submarinerv1.SubmarinerV1Interface {
 	return &fakesubmarinerv1.FakeSubmarinerV1{Fake: &c.Fake}
 }
-
-// Submariner retrieves the SubmarinerV1Client
-func (c *Clientset) Submariner() submarinerv1.SubmarinerV1Interface {
-	return &fakesubmarinerv1.FakeSubmarinerV1{Fake: &c.Fake}
-}


### PR DESCRIPTION
Ran the submariner v1 types with the newer 1.14.1 version of the
k8s code generator. The only changes are removal of deprecated
functions.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>