### PR TITLE
OSX unit test running compatibility and speedups

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,7 +28,6 @@ var _ = Describe("Util", func() {
 
 	Describe("Function CompareEndpointSpec", testCompareEndpointSpec)
 
-	Describe("Function GetDefaultGatewayInterface", testGetDefaultGatewayInterface)
 })
 
 func testParseSecure() {
@@ -250,11 +249,5 @@ func testCompareEndpointSpec() {
 					Hostname:  "host2",
 				})).To(BeFalse())
 		})
-	})
-}
-
-func testGetDefaultGatewayInterface() {
-	It("should find and return a non-nil Interface object", func() {
-		Expect(util.GetDefaultGatewayInterface()).NotTo(BeNil())
 	})
 }

--- a/scripts/lib/find_functions
+++ b/scripts/lib/find_functions
@@ -1,0 +1,24 @@
+function find_go_pkg_dirs() {
+
+    BASE=${2:-.}
+    EXCLUDED_PKG_DIRS=${EXCLUDED_PKG_DIRS:-"vendor test .git .trash-cache bin"}
+
+    for excldir in $EXCLUDED_PKG_DIRS; do
+        FIND_EXCLUDE="-path ./$excldir -prune -o $FIND_EXCLUDE"
+    done
+
+
+ 
+    PACKAGE_DIRS="$(find . $FIND_EXCLUDE -name '*.go' | \
+                      grep .go | \
+                      xargs -I{} dirname {} | \
+                      cut -f2 -d/ | \
+                      sort -u | \
+                      grep -Ev '(^\.$)')"
+
+    if [[ "x$1" != "x--no-trailing-dots" ]]; then
+        PACKAGE_DIRS=$(echo $PACKAGE_DIRS | sed -e 's!^!./!' -e 's!$!/...!')
+    fi
+
+    echo "$BASE $PACKAGE_DIRS"
+}

--- a/scripts/test
+++ b/scripts/test
@@ -3,10 +3,12 @@ set -e
 
 cd $(dirname $0)/..
 
+source $(dirname $0)/lib/find_functions
+
 echo Looking for packages to test
 
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|test)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES=$(find_go_pkg_dirs)
 
 echo Running tests in ${PACKAGES}
 [ "${ARCH}" == "amd64" ] && RACE=-race
-ginkgo ${RACE} -cover -v ${PACKAGES}
+ginkgo ${RACE} -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -3,7 +3,13 @@ set -e
 
 cd $(dirname $0)/..
 
-if [[ $(goimports -l main.go pkg test | wc -l) -gt 0 ]]; then
+source $(dirname $0)/lib/find_functions
+
+EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
+
+PACKAGES=$(find_go_pkg_dirs --no-trailing-dots "*.go")
+
+if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     echo Incorrect formatting, please run goimports
     exit 1
 fi


### PR DESCRIPTION
Skip one test that calls an unsuported netlink function in OSX,
the test will be skipped when the error is "not implemented".

Modify the scripts/test to make the find call compatible with OSX
and linux, also speeding up execution by avoiding "vendor" and
other unnecessary directories being explored by find.

Remove clutter from ginkgo output making it much cleaner.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>