### PR TITLE
Fix scripts/validate in dapper

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -21,7 +21,8 @@ RUN apt-get -q update && \
     curl https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-amd64.tar.gz | tar -xzf - && \
     cp linux-${ARCH}/helm /usr/bin/ && \
     curl -Lo /usr/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-${ARCH} && chmod a+x /usr/bin/kind && \
-    go get -v github.com/onsi/ginkgo/ginkgo && go get -v github.com/onsi/gomega/...
+    go get -v github.com/onsi/ginkgo/ginkgo && go get -v github.com/onsi/gomega/... && \
+    go get golang.org/x/tools/cmd/goimports
 
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
Executing make validate will fail because we're not installing
goimports inside the dapper container.

This commit installs goimports inside dapper.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>