### PR TITLE
Remove unused packages from the Dapper container

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -12,7 +12,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN apt-get -q update && \
-    apt-get install -y gcc ca-certificates git curl vim less file docker.io && \
+    apt-get install -y git curl docker.io && \
     curl https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get -v github.com/rancher/trash && \
     curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
gcc, ca-certificates, vim, less, and file are all unused.

Signed-off-by: Stephen Kitt <skitt@redhat.com>