### PR TITLE
Refactor ipsec to hide implementation

### DIFF
--- a/pkg/cableengine/cableengine.go
+++ b/pkg/cableengine/cableengine.go
@@ -4,7 +4,7 @@ import (
 	"github.com/rancher/submariner/pkg/types"
 )
 
-type CableEngine interface {
+type Engine interface {
 	StartEngine(ignition bool) error
 	ReloadEngine() error
 	StopEngine() error

--- a/pkg/controllers/tunnel/tunnel.go
+++ b/pkg/controllers/tunnel/tunnel.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Controller struct {
-	ce                  cableengine.CableEngine
+	ce                  cableengine.Engine
 	kubeClientSet       kubernetes.Interface
 	submarinerClientSet submarinerClientset.Interface
 	endpointsSynced     cache.InformerSynced
@@ -29,7 +29,7 @@ type Controller struct {
 	endpointWorkqueue workqueue.RateLimitingInterface
 }
 
-func NewController(objectNamespace string, ce cableengine.CableEngine, kubeClientSet kubernetes.Interface, submarinerClientSet submarinerClientset.Interface, endpointInformer submarinerInformers.EndpointInformer) *Controller {
+func NewController(objectNamespace string, ce cableengine.Engine, kubeClientSet kubernetes.Interface, submarinerClientSet submarinerClientset.Interface, endpointInformer submarinerInformers.EndpointInformer) *Controller {
 	tunnelController := &Controller{
 		ce:                  ce,
 		kubeClientSet:       kubeClientSet,


### PR DESCRIPTION
The Engine and Specification structs do not need to be
exported and NewEngine can return the implemented interface
type.

Also renamed the CableEngine interface to Engine to reduce stutter -
so now it reads cableengine.Engine.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>