### PR TITLE
Fix validate and test scripts

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)/..
 
-source $(dirname $0)/lib/find_functions
+source scripts/lib/find_functions
 
 echo Looking for packages to test
 

--- a/scripts/validate
+++ b/scripts/validate
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)/..
 
-source $(dirname $0)/lib/find_functions
+source scripts/lib/find_functions
 
 EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
 


### PR DESCRIPTION
The dirname $0 output is relative, so if we cd first,
and then try to source the lib/find_utils script, it won't
work.

This patch fixes the issue.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>