### PR TITLE
GCC fix for E2E ginkgo tests

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -16,7 +16,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN apt-get -q update && \
-    apt-get install -y git curl docker.io && \
+    apt-get install -y gcc git curl docker.io && \
     curl https://storage.googleapis.com/golang/go1.11.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get -v github.com/rancher/trash && \
     curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \


### PR DESCRIPTION
Because gcc is not present in the build container, the E2E ginkgo tests are failing with error:
exec: "gcc": executable file not found in $PATH

Steps to reproduce:
1. make e2e status=clean
2. docker system prune --all
3. make e2e
